### PR TITLE
Add support for async component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ class UserFooter extends React.Component {
 ```
 
 
-## Props
+## API: `Lazy` component
+
+### Props
 
 #### offset
 Type: `Number|String` Default: `0`
@@ -222,7 +224,7 @@ Type: `Number|String` Default: `offsetVertical`'s value
 The `offsetLeft` option allows you to specify how far to left of the viewport you want to _begin_ displaying your content.
 
 #### offsetRight
-Type: `Number|String` Default: `offsetVertical`'s value
+pType: `Number|String` Default: `offsetVertical`'s value
 
 The `offsetRight` option allows you to specify how far to the right of the viewport you want to _begin_ displaying your content.
 
@@ -273,3 +275,74 @@ A callback function to execute when the content appears on the screen.
 ### Other Props
 
 Other props will be delegated to placeholder.
+
+## API: @lazy
+
+Usage:
+
+``` javascript
+@lazy({
+  style: {
+    height: 720,
+  },
+  onContentVisible: () => console.log('look ma I have been lazyloaded!')
+})
+@routerHooks({
+  fetch: async () => {
+    await fetchData();
+  },
+  defer: async () => {
+    await fetchDeferredData();
+  },
+})
+class MyComponent extends React.Component {
+  render() {
+    return (
+      <div>
+        <img src='http://apod.nasa.gov/apod/image/1502/HDR_MVMQ20Feb2015ouellet1024.jpg' />
+      </div>
+    );
+  }
+}
+```
+
+Or
+
+``` javascript
+const myComponent = @lazy({
+  style: {
+    height: 720,
+  },
+  onContentVisible: () => console.log('look ma I have been lazyloaded!')
+})(MyComponent);
+```
+
+### options
+
+#### getComponent
+
+When the component is null, getComponent will be used to get a component asynchronously.
+
+``` javascript
+const myComponent = @lazy({
+  style: {
+    height: 720,
+  },
+  onContentVisible: () => console.log('look ma I have been lazyloaded!')
+  getComponent: (cb) => {
+    cb(MyComponent);
+  },
+})();
+```
+
+When you use this feature with webpack bundle-loader, the bundle will be loaded lazily.
+
+``` javascript
+const myComponent = @lazy({
+  style: {
+    height: 720,
+  },
+  onContentVisible: () => console.log('look ma I have been lazyloaded!')
+  getComponent: require('bundle-loader?lazy!./MyComponent.js'),
+})();
+```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rimraf lib dist",
     "lint": "eslint src",
     "test": "npm run lint",
-    "prepublish": "npm run build"
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add getComponent to options of `@lazy` decorator.

It can be used to load a component asynchronously.

```javascript
const asyncComponent = @lazy({
  getComponent: require('bundle-loader?lazy!./AsyncComponent'),
})();
```