### PR TITLE
Release/v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ const MyComponent = () => (
   <div>
     Scroll to load images.
     <div className="filler" />
-    <Lazy style={{ height: 762 }} offsetVertical={300}>
+    <Lazy style={{ height: 762 }} offset={300}>
       <img src='http://apod.nasa.gov/apod/image/1502/HDR_MVMQ20Feb2015ouellet1024.jpg' />
     </Lazy>
     <div className="filler" />
-    <Lazy style={{ height: 683 }} offsetTop={200}>
+    <Lazy style={{ height: 683 }} offset="200px 0px 0px 0px">
       <img src='http://apod.nasa.gov/apod/image/1502/2015_02_20_conj_bourque1024.jpg' />
     </Lazy>
     <div className="filler" />
-    <Lazy style={{ height: 480 }} offsetHorizontal={50}>
+    <Lazy style={{ height: 480 }} offset="0px 50px">
       <img src='http://apod.nasa.gov/apod/image/1502/MarsPlume_jaeschke_480.gif' />
     </Lazy>
     <div className="filler" />
@@ -193,46 +193,28 @@ Type: `Boolean` Default: `true`
 Auto reset Lazy component when url changed (history must be set by `setHistory`, see below).
 
 #### offset
-Type: `Number|String` Default: `0`
+Type: `Number|String` Default: `0px`
 
-Aliases: `threshold`
+The `offset` option allows you to specify how far below, above, to the left, and to the right of the viewport you want to _begin_ displaying your content. When `offset` is a string, it must be a DOMString and followed by "%" or "px", e.g. `500px 0px`.
 
-The `offset` option allows you to specify how far below, above, to the left, and to the right of the viewport you want to _begin_ displaying your content. If you specify `0`, your content will be displayed as soon as it is visible in the viewport, if you want to load _1000px_ below or above the viewport, use `1000`.
+This value will be used as rootMargin for IntersectionObserver (See [rootMargin](https://wicg.github.io/IntersectionObserver/#dom-intersectionobserver-rootmargin).
 
-#### offsetVertical
-Type: `Number|String` Default: `offset`'s value
+If you specify a number, such as `100`, then it will be formatted as `100px 0px`.
 
-The `offsetVertical` option allows you to specify how far above and below the viewport you want to _begin_ displaying your content.
+#### placeholder(children, status)
+Type: `Function` Default: `null`
 
-#### offsetHorizontal
-Type: `Number|String` Default: `offset`'s value
-
-The `offsetHorizontal` option allows you to specify how far to the left and right of the viewport you want to _begin_ displaying your contet.
-
-#### offsetTop
-Type: `Number|String` Default: `offsetVertical`'s value
-
-The `offsetTop` option allows you to specify how far above the viewport you want to _begin_ displaying your content.
-
-#### offsetBottom
-Type: `Number|String` Default: `offsetVertical`'s value
-
-The `offsetBottom` option allows you to specify how far below the viewport you want to _begin_ displaying your content.
-
-#### offsetLeft
-Type: `Number|String` Default: `offsetVertical`'s value
-
-The `offsetLeft` option allows you to specify how far to left of the viewport you want to _begin_ displaying your content.
-
-#### offsetRight
-pType: `Number|String` Default: `offsetVertical`'s value
-
-The `offsetRight` option allows you to specify how far to the right of the viewport you want to _begin_ displaying your content.
+A function to render placeholder. You can use this property to customize the placeholder. It receives a children and status. The valid value of status is one of `unload|loading|loaded`.
 
 #### throttle
 Type: `Number|String` Default: `250`
 
 The throttle is managed by an internal function that prevents performance issues from continuous firing of `scroll` events. Using a throttle will set a small timeout when the user scrolls and will keep throttling until the user stops. The default is `250` milliseconds.
+
+### className
+Type: `string`
+
+The className of Lazy component.
 
 ### mode
 Type: `placeholder` | `container` Default: `placeholder`
@@ -240,21 +222,6 @@ Type: `placeholder` | `container` Default: `placeholder`
 `placeholder` mode: Once your content is loaded, placeholder will be removed.
 
 `container` mode: placeholder won't be removed and act as a container when your content are loaded.
-
-### elementType
-Type: `string` Default: `div`
-
-A html element that is used for creating placeholder.
-
-### initStyle
-Type: `object` Default: null
-
-`initStyle` overrides the style of placeholder before your content is loaded.
-
-### className
-Type: `string`
-
-The className of Lazy component.
 
 ### visibleClassName
 Type: `string` Default: `isVisible`

--- a/README.md
+++ b/README.md
@@ -206,11 +206,6 @@ Type: `Function` Default: `null`
 
 A function to render placeholder. You can use this property to customize the placeholder. It receives a children and status. The valid value of status is one of `unload|loading|loaded`.
 
-#### throttle
-Type: `Number|String` Default: `250`
-
-The throttle is managed by an internal function that prevents performance issues from continuous firing of `scroll` events. Using a throttle will set a small timeout when the user scrolls and will keep throttling until the user stops. The default is `250` milliseconds.
-
 ### className
 Type: `string`
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "babel-runtime": "^6.23.0",
     "classnames": "^2.2.5",
     "hoist-non-react-statics": "^1.2.0",
-    "scrollmonitor": "^1.2.3"
+    "intersection-observer": "^0.2.1"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rrr-lazy",
-  "version": "0.16.1",
+  "version": "1.1.0",
   "description": "Lazy load component with react && react-router && react-router-hook.",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/Lazy.js
+++ b/src/Lazy.js
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import scrollMonitor from 'scrollmonitor';
 
+import formatOffset from './formatOffset';
 import { getHistory } from './history';
 
 const Status = {
@@ -10,22 +11,19 @@ const Status = {
   Loaded: 'loaded',
 };
 
-export default class Lazy extends React.Component {
+export default class Lazy extends React.PureComponent {
 
   static propTypes = {
     autoReset: React.PropTypes.bool,
     children: React.PropTypes.node,
     className: React.PropTypes.string,
-    elementType: React.PropTypes.string,
-    initStyle: React.PropTypes.object, // eslint-disable-line react/forbid-prop-types
     mode: React.PropTypes.oneOf(['container', 'placeholder']),
-    offset: React.PropTypes.number,
-    offsetBottom: React.PropTypes.number,
-    offsetHorizontal: React.PropTypes.number,
-    offsetLeft: React.PropTypes.number,
-    offsetRight: React.PropTypes.number,
-    offsetTop: React.PropTypes.number,
-    offsetVertical: React.PropTypes.number,
+    offset: React.PropTypes.oneOfType([
+      React.PropTypes.number,
+      React.PropTypes.string,
+      React.PropTypes.arrayOf(React.PropTypes.number),
+    ]),
+    placeholder: React.PropTypes.func,
     reloadLazyComponent: React.PropTypes.func,
     resetLazyComponent: React.PropTypes.func,
     style: React.PropTypes.object, // eslint-disable-line react/forbid-prop-types
@@ -38,17 +36,10 @@ export default class Lazy extends React.Component {
       autoReset: true,
       children: null,
       className: '',
-      elementType: 'div',
-      initStyle: null,
       mode: 'placeholder',
       offset: 0,
-      offsetBottom: 0,
-      offsetHorizontal: 0,
-      offsetLeft: 0,
-      offsetRight: 0,
-      offsetTop: 0,
-      offsetVertical: 0,
       onContentVisible: () => null,
+      placeholder: null,
       reloadLazyComponent: () => null,
       resetLazyComponent: () => null,
       style: null,
@@ -63,13 +54,6 @@ export default class Lazy extends React.Component {
     this.startWatch = this.startWatch.bind(this);
     this.stopWatch = this.stopWatch.bind(this);
     this.enterViewport = this.enterViewport.bind(this);
-
-    this.placeHolder = React.createElement(
-      props.elementType,
-      {
-        ref: node => (this.node = node),
-      },
-    );
 
     if (!!props.children && React.Children.count(props.children) > 1) {
       console.warn('[rrr-lazy] Only one child is allowed');
@@ -100,28 +84,14 @@ export default class Lazy extends React.Component {
     }
   }
 
-  getOffsets() {
-    const {
-      offset, offsetVertical, offsetHorizontal,
-      offsetTop, offsetBottom, offsetLeft, offsetRight,
-    } = this.props;
-
-    const realOffsetAll = offset;
-    const realOffsetVertical = offsetVertical || realOffsetAll;
-    const realOffsetHorizontal = offsetHorizontal || realOffsetAll;
-
-    return {
-      top: offsetTop || realOffsetVertical,
-      bottom: offsetBottom || realOffsetVertical,
-      left: offsetLeft || realOffsetHorizontal,
-      right: offsetRight || realOffsetHorizontal,
-    };
-  }
-
   startWatch() {
     if (!this.watcher && this.node) {
-      this.watcher = scrollMonitor.create(this.node, this.getOffsets());
-      this.watcher.enterViewport(this.enterViewport);
+      this.watcher = scrollMonitor.create(this.node, formatOffset(this.props.offset));
+      if (this.watcher.isInViewport) {
+        this.enterViewport();
+      } else {
+        this.watcher.enterViewport(this.enterViewport);
+      }
     }
     return this.watcher;
   }
@@ -156,17 +126,19 @@ export default class Lazy extends React.Component {
       return;
     }
     new Promise((resolve, reject) => {
-      if (this.node) {
-        this.setState({ status: Status.Loading }, resolve);
-      } else {
+      if (!this.node) {
         reject('ABORT');
+        return;
       }
+      this.setState({ status: Status.Loading }, resolve);
     })
-      .then(() => this.props.reloadLazyComponent())
       .then(() => {
-        if (this.node) {
-          this.setState({ status: Status.Loaded }, this.props.onContentVisible);
-        }
+        if (!this.node) return Promise.reject('ABORT');
+        return this.props.reloadLazyComponent();
+      })
+      .then(() => {
+        if (!this.node) return Promise.reject('ABORT');
+        return this.setState({ status: Status.Loaded }, this.props.onContentVisible);
       })
       .catch((error) => {
         if (error !== 'ABORT') {
@@ -175,70 +147,59 @@ export default class Lazy extends React.Component {
       });
   }
 
+  renderPlaceholder(children, status) {
+    if (this.props.placeholder) {
+      return React.cloneElement(
+        this.props.placeholder(status, children),
+        {
+          ref: (node) => { this.node = node; },
+        },
+      );
+    }
+
+    return (
+      <div
+        className={cx(
+          'LazyLoad',
+          this.props.className,
+          status === Status.Unload ? this.props.visibleClassName : null,
+        )}
+        ref={(node) => { this.node = node; }}
+        style={this.props.style}
+      >
+        {children}
+      </div>
+    );
+  }
+
   render() {
     /* eslint-disable no-unused-vars */
     const {
       autoReset,
       children,
       className,
-      elementType,
-      initStyle,
       mode,
       offset,
-      offsetBottom,
-      offsetHorizontal,
-      offsetLeft,
-      offsetRight,
-      offsetTop,
-      offsetVertical,
       reloadLazyComponent,
       resetLazyComponent,
       style,
       visibleClassName,
       onContentVisible,
-      ...restProps
     } = this.props;
     /* eslint-enable no-unused-vars */
-
     const status = this.state.status;
-
     // Unload
     if (status === Status.Unload) {
-      return React.cloneElement(
-        this.placeHolder,
-        {
-          ...restProps,
-          className: cx('LazyLoad', className),
-          style: initStyle || style,
-        },
-      );
+      return this.renderPlaceholder(null, status);
     }
-
     // Loading
     if (status === Status.Loading) {
-      return React.cloneElement(
-        this.placeHolder,
-        {
-          ...restProps,
-          className: cx('LazyLoad', className),
-          style: initStyle,
-        },
-        children === null ? null : React.cloneElement(children, restProps),
+      return this.renderPlaceholder(
+        children,
+        status,
       );
     }
-
     // Loaded
-    if (mode === 'container') {
-      return React.cloneElement(
-        this.placeHolder,
-        {
-          ...restProps,
-          className: cx('LazyLoad', className, visibleClassName),
-          style,
-        },
-        children === null ? null : React.cloneElement(children, restProps),
-      );
-    }
-    return children === null ? null : React.cloneElement(children, restProps);
+    return mode === 'container' ? this.renderPlaceholder(children, status) : children;
   }
 }

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -16,14 +16,13 @@ const getDisplayName = (Component, displayName) => {
 };
 
 export default (options = {}) => (Component = null) => {
-  class LazyDecorated extends React.Component {
+  class LazyDecorated extends React.PureComponent {
     static propTypes = {
       reloadComponent: React.PropTypes.func,
     };
 
     static get defaultProps() {
       return {
-        children: null,
         reloadComponent: () => null,
       };
     }
@@ -67,7 +66,10 @@ export default (options = {}) => (Component = null) => {
         if (this.state.Component) {
           hoistStatics(LazyDecorated, this.state.Component);
         }
-        return this.props.reloadComponent();
+        if (typeof this.props.reloadComponent === 'function') {
+          this.props.reloadComponent();
+        }
+        return null;
       });
     }
 

--- a/src/formatOffset.js
+++ b/src/formatOffset.js
@@ -1,66 +1,9 @@
 export default function formatOffset(offset) {
   if (!offset) {
-    return {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0,
-    };
+    return '0px';
   }
   if (typeof offset === 'number') {
-    return {
-      top: offset,
-      right: offset,
-      bottom: offset,
-      left: offset,
-    };
+    return `${offset}px 0px`;
   }
-
-  // typeof offset === 'string'
-  let offsets;
-  if (typeof offset === 'string') {
-    offsets = offset.split(/\s+/).filter(x => x);
-  } else if (Array.isArray(offset)) {
-    offsets = offset;
-  } else {
-    throw new Error('offset must be number | string | array');
-  }
-  const len = offsets.length;
-  if (len === 0) {
-    return {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0,
-    };
-  } else if (len === 1) {
-    return {
-      top: offsets[0],
-      right: offsets[0],
-      bottom: offsets[0],
-      left: offsets[0],
-    };
-  } else if (len === 2) {
-    return {
-      top: offsets[0],
-      right: offsets[1],
-      bottom: offsets[0],
-      left: offsets[1],
-    };
-  } else if (len === 3) {
-    return {
-      top: offsets[0],
-      right: offsets[1],
-      bottom: offsets[2],
-      left: offsets[1],
-    };
-  } else if (len === 4) {
-    return {
-      top: offsets[0],
-      right: offsets[1],
-      bottom: offsets[2],
-      left: offsets[3],
-    };
-  }
-  throw new Error(`Invalid offset ${offset}`);
+  return offset;
 }

--- a/src/formatOffset.js
+++ b/src/formatOffset.js
@@ -1,0 +1,66 @@
+export default function formatOffset(offset) {
+  if (!offset) {
+    return {
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    };
+  }
+  if (typeof offset === 'number') {
+    return {
+      top: offset,
+      right: offset,
+      bottom: offset,
+      left: offset,
+    };
+  }
+
+  // typeof offset === 'string'
+  let offsets;
+  if (typeof offset === 'string') {
+    offsets = offset.split(/\s+/).filter(x => x);
+  } else if (Array.isArray(offset)) {
+    offsets = offset;
+  } else {
+    throw new Error('offset must be number | string | array');
+  }
+  const len = offsets.length;
+  if (len === 0) {
+    return {
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    };
+  } else if (len === 1) {
+    return {
+      top: offsets[0],
+      right: offsets[0],
+      bottom: offsets[0],
+      left: offsets[0],
+    };
+  } else if (len === 2) {
+    return {
+      top: offsets[0],
+      right: offsets[1],
+      bottom: offsets[0],
+      left: offsets[1],
+    };
+  } else if (len === 3) {
+    return {
+      top: offsets[0],
+      right: offsets[1],
+      bottom: offsets[2],
+      left: offsets[1],
+    };
+  } else if (len === 4) {
+    return {
+      top: offsets[0],
+      right: offsets[1],
+      bottom: offsets[2],
+      left: offsets[3],
+    };
+  }
+  throw new Error(`Invalid offset ${offset}`);
+}

--- a/src/watchOnce.js
+++ b/src/watchOnce.js
@@ -1,0 +1,53 @@
+import formatOffset from './formatOffset';
+
+const canUseDOM = !!(
+  typeof window !== 'undefined' &&
+    window.document &&
+    window.document.createElement
+);
+
+if (canUseDOM) {
+  // eslint-disable-next-line global-require
+  require('intersection-observer');
+}
+
+const animationFrame = typeof window !== 'undefined'
+      ? (window.requestAnimationFrame ||
+         window.webkitRequestAnimationFrame ||
+         window.mozRequestAnimationFrame) : setTimeout;
+
+const observers = {};
+const callbacks = new WeakMap();
+
+function findObserver(offsetString) {
+  let observer = observers[offsetString];
+  if (!observer) {
+    observer = new IntersectionObserver((entries) => {
+      for (let i = 0, len = entries.length; i < len; i += 1) {
+        const entry = entries[i];
+        if (entry.intersectionRatio <= 0) return;
+        const element = entry.target;
+        const callback = callbacks.get(element);
+        if (callback) {
+          animationFrame(callback);
+          callbacks.delete(element);
+        }
+        observer.unobserve(element);
+      }
+    }, {
+      rootMargin: offsetString,
+    });
+    observers[offsetString] = observer;
+  }
+  return observer;
+}
+
+export default function watchOnce(element, offset, callback) {
+  const offsetString = formatOffset(offset);
+  const observer = findObserver(offsetString);
+  callbacks.set(element, callback);
+  observer.observe(element);
+  return () => {
+    observer.unobserve(element);
+  };
+}


### PR DESCRIPTION
- **[BREAK]** remove `offsetVertical` `offsetHorizontal` `offsetTop` `offsetBottom` `offsetLeft` `offsetRight` , use `offset` instead
- **[BREAK]** `offset` can be a number or string. When it is a string, it must be a DOMString as the same as `margin` or `padding`, e.g. `500px 0px`. Each value must be followed by "%" or "px". When it is a number, it will be formatted as `${number}px 0px`.
- **[BREAK]** remove `elementType` and `initStyle`, use `placeholder(children, status)` to customize placeholder.
- **[BREAK]** add `placeholder(children, status)` as props. It can be used to customize the placeholder. The value of status is `unload|loading|loaded`.
- **[ENHANCEMENT]** use [`IntersectionObserver`](https://wicg.github.io/IntersectionObserver) instead of scrollmonitor.
