### PR TITLE
Release/v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 rrr-lazy
 =========================
 
+[![Greenkeeper badge](https://badges.greenkeeper.io/kouhin/rrr-lazy.svg)](https://greenkeeper.io/)
+
 Lazy load component with react && react-router && react-router-hook.
 
 [![CircleCI](https://circleci.com/gh/kouhin/rrr-lazy/tree/master.svg?style=svg)](https://circleci.com/gh/kouhin/rrr-lazy/tree/master)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 rrr-lazy
 =========================
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/kouhin/rrr-lazy.svg)](https://greenkeeper.io/)
-
 Lazy load component with react && react-router && react-router-hook.
 
 [![CircleCI](https://circleci.com/gh/kouhin/rrr-lazy/tree/master.svg?style=svg)](https://circleci.com/gh/kouhin/rrr-lazy/tree/master)
 [![dependency status](https://david-dm.org/kouhin/rrr-lazy.svg?style=flat-square)](https://david-dm.org/kouhin/rrr-lazy)
+[![Greenkeeper badge](https://badges.greenkeeper.io/kouhin/rrr-lazy.svg)](https://greenkeeper.io/)
 
 ## Installationg
 rrr-lazy requires **React 0.14 or later.**

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ rrr-lazy
 
 Lazy load component with react && react-router && react-router-hook.
 
-[![CircleCI](https://circleci.com/gh/kouhin/rrr-lazy/tree/develop.svg?style=svg)](https://circleci.com/gh/kouhin/rrr-lazy/tree/develop)
+[![CircleCI](https://circleci.com/gh/kouhin/rrr-lazy/tree/master.svg?style=svg)](https://circleci.com/gh/kouhin/rrr-lazy/tree/master)
 [![dependency status](https://david-dm.org/kouhin/rrr-lazy.svg?style=flat-square)](https://david-dm.org/kouhin/rrr-lazy)
 
 ## Installationg

--- a/package.json
+++ b/package.json
@@ -31,24 +31,25 @@
   "author": "Bin Hou <houbin217jz@gmail.com> (https://twitter.com/houbin217jz)",
   "license": "MIT",
   "devDependencies": {
-    "babel-cli": "^6.23.0",
-    "babel-core": "^6.23.1",
-    "babel-eslint": "^7.1.1",
+    "babel-cli": "^6.24.1",
+    "babel-core": "^6.24.1",
+    "babel-eslint": "^7.2.3",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.2.1",
-    "babel-preset-react": "^6.23.0",
-    "babel-preset-stage-0": "^6.22.0",
-    "eslint-config-airbnb-deps": "^14.1.0",
+    "babel-preset-env": "^1.5.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
+    "eslint-config-airbnb-deps": "^15.0.1",
     "eslint-plugin-babel": "^4.1.1",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "rimraf": "^2.6.1"
   },
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "classnames": "^2.2.5",
     "hoist-non-react-statics": "^1.2.0",
-    "intersection-observer": "^0.2.1"
+    "intersection-observer": "^0.2.1",
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rrr-lazy",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Lazy load component with react && react-router && react-router-hook.",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/Lazy.js
+++ b/src/Lazy.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import cx from 'classnames';
+import PropTypes from 'prop-types';
 
 import { getHistory } from './history';
 import watchOnce from './watchOnce';
@@ -13,20 +14,20 @@ const Status = {
 export default class Lazy extends React.PureComponent {
 
   static propTypes = {
-    autoReset: React.PropTypes.bool,
-    children: React.PropTypes.node,
-    className: React.PropTypes.string,
-    mode: React.PropTypes.oneOf(['container', 'placeholder']),
-    offset: React.PropTypes.oneOfType([
-      React.PropTypes.number,
-      React.PropTypes.string,
+    autoReset: PropTypes.bool,
+    children: PropTypes.node,
+    className: PropTypes.string,
+    mode: PropTypes.oneOf(['container', 'placeholder']),
+    offset: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
     ]),
-    placeholder: React.PropTypes.func,
-    reloadLazyComponent: React.PropTypes.func,
-    resetLazyComponent: React.PropTypes.func,
-    style: React.PropTypes.object, // eslint-disable-line react/forbid-prop-types
-    visibleClassName: React.PropTypes.string,
-    onContentVisible: React.PropTypes.func,
+    placeholder: PropTypes.func,
+    reloadLazyComponent: PropTypes.func,
+    resetLazyComponent: PropTypes.func,
+    style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+    visibleClassName: PropTypes.string,
+    onContentVisible: PropTypes.func,
   };
 
   static get defaultProps() {

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import hoistStatics from 'hoist-non-react-statics';
 
 import Lazy from './Lazy';
@@ -27,7 +28,7 @@ function interopRequireDefault(obj) {
 export default (options = {}) => (Component = null) => {
   class LazyDecorated extends React.PureComponent {
     static propTypes = {
-      reloadComponent: React.PropTypes.func,
+      reloadComponent: PropTypes.func,
     };
 
     static get defaultProps() {


### PR DESCRIPTION
- Use prop-types instead of React.PropTypes for React 15.5